### PR TITLE
Added option to pass credentials in msg rather than configured in the flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ npm install node-red-contrib-salesforce
 
 ## Usage
 
-Each node uses a connection object to hold and share Salesforce connected app settings (consumer key, consumer secret, username, etc.). This determines the org that each node operates against.
+<p>Each node uses a connection object to hold and share Salesforce connected app settings (consumer key, consumer secret, username, etc.). This determines the org that each node operates against.</p>
+<p>The credential fields can be left blank and passed in the message (msg.sf), this allows you to store them outside of the flow so that they will not be exposed when exporting it.</p>
 
 ### SOQL
 

--- a/connection-config.html
+++ b/connection-config.html
@@ -3,12 +3,12 @@
         category: 'config',
         defaults: {
             name: {value:'', required: true},
-            consumerKey: {required: true},
-            consumerSecret: {required: true},
+            consumerKey: {value:''},
+            consumerSecret: {value:''},
             callbackUrl: {required: true},
             environment: {value: 'production', required: true},
-            username: {required: true},
-            password: {required: true},
+            username: {value:''},
+            password: {value:''},
         },
         label: function() {
             return this.name || this.username + ' connection';
@@ -50,11 +50,11 @@
     </div>
     <div class="form-row" style="white-space:nowrap">
         <label for="node-config-input-consumerKey"><i class="fa fa-key"></i> Consumer Key</label>
-        <input type="text" id="node-config-input-consumerKey">
+        <input type="text" id="node-config-input-consumerKey" placeholder="msg.sf.consumerKey">
     </div>
     <div class="form-row" style="white-space:nowrap">
         <label for="node-config-input-consumerSecret"><i class="fa fa-user-secret"></i> Consumer Secret</label>
-        <input type="password" id="node-config-input-consumerSecret">
+        <input type="password" id="node-config-input-consumerSecret" placeholder="msg.sf.consumerSecret">
     </div>
     <div class="form-row" style="white-space:nowrap">
         <label for="node-config-input-callbackUrl"><i class="fa fa-history"></i> Callback URL</label>
@@ -69,10 +69,10 @@
     </div>
     <div class="form-row">
         <label for="node-config-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-config-input-username">
+        <input type="text" id="node-config-input-username" placeholder="msg.sf.username">
     </div>
     <div class="form-row">
         <label for="node-config-input-password"><i class="fa fa-lock"></i> Password</label>
-        <input type="password" id="node-config-input-password">
+        <input type="password" id="node-config-input-password" placeholder="msg.sf.password">
     </div>
 </script>

--- a/dml.js
+++ b/dml.js
@@ -20,6 +20,22 @@ module.exports = function(RED) {
         config.object = msg.object;
       }
 
+      // get credentials from msg.sf if present and config values are blank
+      if (msg.hasOwnProperty("sf")) {
+        if (msg.sf.consumerKey && this.connection.consumerKey === '') {
+          this.connection.consumerKey = msg.sf.consumerKey;
+        }
+        if (msg.sf.consumerSecret && this.connection.consumerSecret === '') {
+          this.connection.consumerSecret = msg.sf.consumerSecret;
+        }
+        if (msg.sf.username && this.connection.username === '') {
+          this.connection.username = msg.sf.username;
+        }
+        if (msg.sf.password && this.connection.password === '') {
+          this.connection.password = msg.sf.password;
+        }
+      }
+      
       // create connection object
       var org = nforce.createConnection({
         clientId: this.connection.consumerKey,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-salesforce",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A set of Node-RED nodes to interact with Salesforce and Force.com.",
   "author": {
     "name": "Jeff Douglas",

--- a/soql.js
+++ b/soql.js
@@ -16,6 +16,22 @@ module.exports = function(RED) {
         config.query = msg.query;
       }
 
+      // get credentials from msg.sf if present and config values are blank
+      if (msg.hasOwnProperty("sf")) {
+        if (msg.sf.consumerKey && this.connection.consumerKey === '') {
+          this.connection.consumerKey = msg.sf.consumerKey;
+        }
+        if (msg.sf.consumerSecret && this.connection.consumerSecret === '') {
+          this.connection.consumerSecret = msg.sf.consumerSecret;
+        }
+        if (msg.sf.username && this.connection.username === '') {
+          this.connection.username = msg.sf.username;
+        }
+        if (msg.sf.password && this.connection.password === '') {
+          this.connection.password = msg.sf.password;
+        }
+      }
+      
       // create connection object
       var org = nforce.createConnection({
         clientId: this.connection.consumerKey,

--- a/sosl.js
+++ b/sosl.js
@@ -16,6 +16,22 @@ module.exports = function(RED) {
         config.query = msg.query;
       }
 
+      // get credentials from msg.sf if present and config values are blank
+      if (msg.hasOwnProperty("sf")) {
+        if (msg.sf.consumerKey && this.connection.consumerKey === '') {
+          this.connection.consumerKey = msg.sf.consumerKey;
+        }
+        if (msg.sf.consumerSecret && this.connection.consumerSecret === '') {
+          this.connection.consumerSecret = msg.sf.consumerSecret;
+        }
+        if (msg.sf.username && this.connection.username === '') {
+          this.connection.username = msg.sf.username;
+        }
+        if (msg.sf.password && this.connection.password === '') {
+          this.connection.password = msg.sf.password;
+        }
+      }
+      
       // create connection object
       var org = nforce.createConnection({
         clientId: this.connection.consumerKey,

--- a/streaming.js
+++ b/streaming.js
@@ -7,6 +7,22 @@ module.exports = function(RED) {
     this.connection = RED.nodes.getNode(config.connection);
     var node = this;
 
+    // get credentials from msg.sf if present and config values are blank
+    if (msg.hasOwnProperty("sf")) {
+      if (msg.sf.consumerKey && this.connection.consumerKey === '') {
+        this.connection.consumerKey = msg.sf.consumerKey;
+      }
+      if (msg.sf.consumerSecret && this.connection.consumerSecret === '') {
+        this.connection.consumerSecret = msg.sf.consumerSecret;
+      }
+      if (msg.sf.username && this.connection.username === '') {
+        this.connection.username = msg.sf.username;
+      }
+      if (msg.sf.password && this.connection.password === '') {
+        this.connection.password = msg.sf.password;
+      }
+    }
+    
     // create connection object
     var org = nforce.createConnection({
       clientId: this.connection.consumerKey,


### PR DESCRIPTION
I've added the option to pass the Salesforce credentials in the msg object rather than store them in the configuration node.
The reasoning behind this is to allow these to be managed externally to the flow if needed, and to avoid exposing them in plain text in the flow export.